### PR TITLE
Clone repos in the same folder / namespace structure

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,19 +35,19 @@ const generateAuthorizedRepoUrl = (url) => {
     for(const group of groups){
         let groupProjects = await authorizedGetRequest(`${server}/api/v4/groups/${group.id}/projects`);
         for(const groupProject of groupProjects){
-            repositories.push({name:groupProject.name, path: groupProject.path, url: groupProject.http_url_to_repo});
+            repositories.push({name:groupProject.name, path: groupProject.path_with_namespace, url: groupProject.http_url_to_repo});
         }
     }
 
     const user = await authorizedGetRequest(`${server}/api/v4/user`);
     const userProjects = await authorizedGetRequest(`${server}/api/v4/users/${user.id}/projects`);
     for(const userProject of userProjects){
-        repositories.push({name:userProject.name, path: userProject.path, url: userProject.http_url_to_repo});
+        repositories.push({name:userProject.name, path: userProject.path_with_namespace, url: userProject.http_url_to_repo});
     }
 
     for(const repository of repositories){
         await git.Clone(generateAuthorizedRepoUrl(repository.url), `${repositoryBackupFolder}${repository.path}`);
-        console.info(`"${repository.name}" repository cloned.`);
+        console.info(`"${repository.path}" repository cloned.`);
     }
 
     const snippets = await authorizedGetRequest(`${server}/api/v4/snippets`);


### PR DESCRIPTION
When cloning, repos should be placed in the same folder / namespace structure.

This will prevent that:
- doing backups of repos from different groups / accounts get mixed in the same root folder
- repos with the same name, but different folders in the server get ignored (only the first is cloned, the others are skipped because of name collision)

I think that those wanting to backup a lot of stuff from Gitlab would like things to come arranged by namespaces instead of everything dumped in a root folder.